### PR TITLE
Externalize WoT application_id and remove hardcoded secrets (#22)

### DIFF
--- a/src/main/java/com/wotos/wotosvehicleservice/config/Settings.java
+++ b/src/main/java/com/wotos/wotosvehicleservice/config/Settings.java
@@ -7,8 +7,15 @@ import org.springframework.context.annotation.Configuration;
 public class Settings {
     public static String WG_APP_ID;
 
+    /**
+     * Binds the WoT {@code application_id} from the {@code env.wg-app-id} property,
+     * which resolves the {@code WG_APP_ID} environment variable at runtime (injected
+     * from GitHub Actions secrets in CI and the deployment secret store in prod). The
+     * empty default lets the context start without the secret present — e.g. in
+     * tests/CI, where outbound WoT calls are mocked.
+     */
     public Settings(
-            @Value("env.wg-app-id") String wgAppId
+            @Value("${env.wg-app-id:}") String wgAppId
     ) {
         Settings.WG_APP_ID = wgAppId;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,17 @@
+# The WoT application_id is injected from the WG_APP_ID environment variable at
+# runtime — sourced from GitHub Actions secrets in CI and the deployment secret
+# store in prod (a Spring Cloud Config server may also override it). Secrets must
+# never be hardcoded here or committed to source control.
+# The datasource block is currently inert (JPA and the MySQL driver are disabled
+# in pom.xml) and is retained as scaffolding for the planned vehicle CRUD work (#7).
 spring:
   jpa:
     generate-ddl: true
   datasource:
     initialization-mode: always
-    url: jdbc:mysql://localhost:3306/wotos_vehicles_database?useSSL=false
-    username: root
-    password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
 
 env:
-  wg-app-id: "da67d6dbc1f23b9e54688febe7d5da56"
+  wg-app-id: ${WG_APP_ID:}
   urls:
     world_of_tanks_api: "https://api.worldoftanks.com/wot"


### PR DESCRIPTION
## Summary
Removes hardcoded secrets from `wotos-vehicle-service` source and externalizes the WoT `application_id` so it is injected at runtime. Part of **#22 — Phase 3: Security Hardening** (P0).

- **`application.yml`** — removed the hardcoded MySQL `url`/`username`/`password` and the WoT `application_id`. `env.wg-app-id` now resolves from `${WG_APP_ID:}`, injectable from GitHub Actions secrets in CI and the deployment secret store in prod (a Spring Cloud Config server may also override it).
- **`Settings.java`** — fixed the broken `@Value("env.wg-app-id")` placeholder (it injected the literal string `env.wg-app-id` as the app id) to `@Value("${env.wg-app-id:}")`, with an empty default so the context still starts in tests/CI where outbound WoT calls are mocked. Javadoc updated to describe the real mechanism.

The inert `datasource` block (JPA + MySQL driver are commented out in `pom.xml`; the service has no DB usage) is retained as scaffolding for the planned vehicle CRUD work (#7), now without credentials.

## Testing
- `./mvnw -o test` (JDK 17) → **BUILD SUCCESS**, Tests run: 3, Failures: 0, Errors: 0.
- Full `@SpringBootTest` context loads with the secret removed: the config-server fetch at `:4040` is refused, logs a warning, and continues (non-fail-fast), as designed.

## ⚠️ Required follow-up (cannot be done in code)
- [ ] **Rotate the WoT `application_id`** on the Wargaming developer portal — the previously committed key (`da67d6db…`) remains in git history and removing it from the working tree does **not** invalidate it. This is part of #22's acceptance ("removed from source **and rotated**").
- [ ] Add a `WG_APP_ID` GitHub Actions secret / deployment env var so the rotated key is supplied at runtime. (CI tests don't need it — WoT calls are mocked.)

## Scope
Addresses the secret-externalization slice of #22 (the `22-externalize-secrets` branch). The remaining Phase 3 work in #22 — JWT validation filter and role enforcement on write endpoints — is **out of scope** for this PR and intentionally not linked with a closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)